### PR TITLE
Migrate Lambdas to use k8s manifests 

### DIFF
--- a/local/app-emissary-provisioner/index.js
+++ b/local/app-emissary-provisioner/index.js
@@ -53,6 +53,8 @@ async function kubeApply(specPath = '../prod/purpleteam-s2-containers/app-emissa
       created.push(response.body);
     }
   });
+
+  return created
 }
 
 

--- a/local/app-emissary-provisioner/index.js
+++ b/local/app-emissary-provisioner/index.js
@@ -1,13 +1,50 @@
-// Copyright (C) 2017-2022 BinaryMist Limited. All rights reserved.
+const k8s = require('@kubernetes/client-node');
+const fs = require('fs');
+const yaml = require('js-yaml');
+const util = require('util');
 
-// Use of this software is governed by the Business Source License
-// included in the file /licenses/bsl.md
+/**
+ * https://github.com/kubernetes-client/javascript/blob/master/examples/typescript/apply/apply-example.ts
+ * @todo spec path shoould be an env variable?
+ * @todo test for ideal S3 provisioing time for creating a new deployment
+ * @todo fill response objects with k8s pod names, maybe query for list pod?
+ * @param {*} specPath
+ * @returns Array of created resources
+ */
+async function kubeApply(specPath = '../prod/purpleteam-s2-containers/app-emissary/deployment.yaml', replicasNum = 10) {
+  const kc = new k8s.KubeConfig();
+  kc.loadFromDefault();
+  const client = k8s.KubernetesObjectApi.makeApiClient(kc);
+  const fsReadFileP = util.promisify(fs.readFile);
+  const specString = await fsReadFileP(specPath, 'utf8');
+  const specs = yaml.loadAll(specString);
+  const validSpecs = specs.filter((s) => s && s.kind && s.metadata);
+  const created = [];
+  validSpecs.forEach(async (doc) => {
+    const spec = doc;
+    spec.metadata.annotations = spec.metadata.annotations || {};
+    delete spec.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'];
+    spec.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'] = JSON.stringify(spec);
 
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0
+    /**
+     *scales the number of replica sets to DTO items length if the manifest type is a deployment
+     * */
 
-const axios = require('axios');
+    if (spec.kind === 'Deployment') {
+      spec.spec.replicas = replicasNum;
+    }
+
+    try {
+      await client.read(spec);
+      const response = await client.patch(spec);
+      created.push(response.body);
+    } catch (e) {
+      const response = await client.create(spec);
+      created.push(response.body);
+    }
+  });
+}
+
 
 const internals = {};
 
@@ -66,30 +103,24 @@ internals.deployEmissaries = async (dTOItems) => {
 
   if (numberOfRequestedEmissaries < 1 || numberOfRequestedEmissaries > 12) throw new Error(`The number of app-emissaries requested was: ${numberOfRequestedEmissaries}. The supported number of Test Sessions is from 1-12 inclusive.`);
 
-  // timeout in axios is for response times only, if the end-point is down, it will still take a long time. So we just wrap the actual request.
-  const http = axios.create({ /* default is 0 (no timeout) */ baseURL: 'http://docker-compose-ui:5000/api/v1', headers: { 'Content-type': 'application/json' } });
-
-  const promisedResponse = http.put('/services', { service: 'zap', project: 'app-emissary', num: numberOfRequestedEmissaries });
+  const promisedResponse = kubeApply('', numberOfRequestedEmissaries);
   const resolved = await promiseAllTimeout([promisedResponse], s2ProvisioningTimeout);
 
-  !resolved[0] && (result.error = 'Timeout exceeded: App Emissary container(s) took too long to start. Although they timed out, they may have still started. Also check that docker-compose-ui is up.');
-
+  !resolved[0] && (result.error = 'Timeout exceeded: App Emissary container(s) took too long to start. Although they timed out, they may have still started. Also check that the minikube clutser is up.');
   result.items = dTOItems.map((cV, i) => {
     const itemClone = { ...cV };
     itemClone.appEmissaryContainerName = `appemissary_zap_${i + 1}`;
     return itemClone;
   });
-
   return result;
 };
 
 exports.provisionAppEmissaries = async (event, context) => { // eslint-disable-line no-unused-vars
   internals.s2ProvisioningTimeout = process.env.S2_PROVISIONING_TIMEOUT * 1000;
   const { provisionViaLambdaDto: { items } } = event;
-  const { deployEmissaries, printEnv } = internals;
+  const { printEnv } = internals;
   printEnv();
-  const result = await deployEmissaries(items);
-
+  const result = await internals.deployEmissaries(items);
   const response = {
     // 'statusCode': 200,
     body: { provisionedViaLambdaDto: result }
@@ -97,3 +128,4 @@ exports.provisionAppEmissaries = async (event, context) => { // eslint-disable-l
 
   return response;
 };
+

--- a/local/app-emissary-provisioner/index.js
+++ b/local/app-emissary-provisioner/index.js
@@ -1,3 +1,13 @@
+// Copyright (C) 2017-2022 BinaryMist Limited. All rights reserved.
+
+// Use of this software is governed by the Business Source License
+// included in the file /licenses/bsl.md
+
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+
 const k8s = require('@kubernetes/client-node');
 const fs = require('fs');
 const yaml = require('js-yaml');


### PR DESCRIPTION

* An env variable should probably feed the path for the k8s manifest 
*  Including the pod names just as the current DC UI returns the container names would require an extra call to the k8s API which would increase the lambda execution time, is that acceptable?
* 
### Checklist

* [x] I have read the contributing guidelines
* [x] I have read the documentation
* [x] I have included a descriptive Pull Request title
* [x] I have included a Pull Request description of my changes
* [ ] I have included tests where/when required (see contributing guidelines)
* [ ] I have included documentation modifications/additions where/when required (see contributing guidelines)
